### PR TITLE
Fix path for image uploads

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -461,7 +461,7 @@ $editCategoryId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
             preview.appendChild(progressBar);
             
             // Subir archivo
-            fetch('admin/upload_handler.php', {
+            fetch('../admin/upload_handler.php', {
                 method: 'POST',
                 body: formData
             })

--- a/admin/products.php
+++ b/admin/products.php
@@ -548,7 +548,7 @@ $editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
             preview.appendChild(progressBar);
             
             // Subir archivos
-            fetch('admin/upload_handler.php', {
+            fetch('../admin/upload_handler.php', {
                 method: 'POST',
                 body: formData
             })

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -562,7 +562,7 @@ $settings = [
             progressBar.innerHTML = '<div class="upload-progress-bar" style="width: 0%"></div>';
             preview.appendChild(progressBar);
             
-            fetch('admin/upload_handler_simple.php', {
+            fetch('../admin/upload_handler_simple.php', {
                 method: 'POST',
                 body: formData
             })
@@ -620,7 +620,7 @@ $settings = [
             progressBar.innerHTML = '<div class="upload-progress-bar" style="width: 0%"></div>';
             preview.appendChild(progressBar);
             
-            fetch('admin/upload_handler_simple.php', {
+            fetch('../admin/upload_handler_simple.php', {
                 method: 'POST',
                 body: formData
             })

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -293,7 +293,7 @@ function handleFileUpload(source, preview, folder = 'products') {
     preview.appendChild(progressBar);
     
     // Upload files
-    fetch('admin/upload_handler.php', {
+    fetch('../admin/upload_handler.php', {
         method: 'POST',
         body: formData
     })


### PR DESCRIPTION
## Summary
- fix JS fetch path for uploading images
- ensure admin pages use correct upload handler path

## Testing
- `php -l admin/categories.php`
- `php -l admin/products.php`
- `php -l admin/settings.php`


------
https://chatgpt.com/codex/tasks/task_b_6877284cea20832689572af2c444ace7