### PR TITLE
Fix dynamic SITE_URL detection

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -3,7 +3,18 @@
 session_start();
 
 // Configuración general
-define('SITE_URL', 'http://localhost/TiendawebAlquimia');
+// Intentar detectar automáticamente la URL de la aplicación para evitar
+// problemas cuando el proyecto no se aloja exactamente en "TiendawebAlquimia".
+// Si necesitas forzar una URL distinta, define SITE_URL antes de incluir
+// este archivo.
+if (!defined('SITE_URL')) {
+    $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    $docRoot = str_replace('\\', '/', $_SERVER['DOCUMENT_ROOT'] ?? '');
+    $rootDir = str_replace('\\', '/', dirname(__DIR__));
+    $basePath = rtrim(str_replace($docRoot, '', $rootDir), '/');
+    define('SITE_URL', $protocol . $host . ($basePath ? '/' . ltrim($basePath, '/') : ''));
+}
 define('SITE_NAME', 'AlquimiaTechnologic');
 define('ADMIN_EMAIL', 'admin@alquimiatechnologic.com');
 


### PR DESCRIPTION
## Summary
- detect SITE_URL automatically instead of hardcoding path

## Testing
- `php -l config/config.php`
- `php -l admin/upload_handler.php`
- `php -l admin/upload_handler_simple.php`
- `php -l test_image_upload_final.php`


------
https://chatgpt.com/codex/tasks/task_b_6877ac907b8c8326b057435a0a8bb8da