### PR TITLE
Fix product image paths

### DIFF
--- a/admin/upload_handler.php
+++ b/admin/upload_handler.php
@@ -23,7 +23,7 @@ if (!isset($_POST['csrf_token']) || !verifyCSRFToken($_POST['csrf_token'])) {
 // Configuración de carga
 $folder = preg_replace('/[^a-zA-Z0-9_-]/', '', $_POST['folder'] ?? 'products');
 $uploadDir = __DIR__ . '/../assets/images/' . $folder . '/';
-$baseUrl = rtrim(SITE_URL, '/') . '/';
+$relativeBase = 'assets/images/' . $folder . '/';
 $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 $maxFileSize = 5 * 1024 * 1024; // 5MB
 $maxFiles = 5;
@@ -193,8 +193,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['images'])) {
                 $resizeResult = resizeImage($filePath, $resizedPath, 300, 300);
                 if ($resizeResult) {
                     $uploadedFiles[] = [
-                        'original' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
-                        'thumbnail' => $baseUrl . 'assets/images/' . $folder . '/thumb_' . $fileName,
+                        'original' => $relativeBase . $fileName,
+                        'thumbnail' => $relativeBase . 'thumb_' . $fileName,
                         'name' => $originalName
                     ];
                 } else {
@@ -202,8 +202,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['images'])) {
                     log_upload_error($msg);
                     // Si no se puede redimensionar, usar la original
                     $uploadedFiles[] = [
-                        'original' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
-                        'thumbnail' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
+                        'original' => $relativeBase . $fileName,
+                        'thumbnail' => $relativeBase . $fileName,
                         'name' => $originalName
                     ];
                 }

--- a/admin/upload_handler_simple.php
+++ b/admin/upload_handler_simple.php
@@ -7,7 +7,7 @@
 // Configuración de carga
 $folder = preg_replace('/[^a-zA-Z0-9_-]/', '', $_POST['folder'] ?? 'products');
 $uploadDir = __DIR__ . '/../assets/images/' . $folder . '/';
-$baseUrl = 'http://localhost/codex/'; // URL base hardcodeada para pruebas
+$relativeBase = 'assets/images/' . $folder . '/';
 $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 $maxFileSize = 5 * 1024 * 1024; // 5MB
 $maxFiles = 5;
@@ -176,8 +176,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['images'])) {
                 $resizeResult = resizeImage($filePath, $resizedPath, 300, 300);
                 if ($resizeResult) {
                     $uploadedFiles[] = [
-                        'original' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
-                        'thumbnail' => $baseUrl . 'assets/images/' . $folder . '/thumb_' . $fileName,
+                        'original' => $relativeBase . $fileName,
+                        'thumbnail' => $relativeBase . 'thumb_' . $fileName,
                         'name' => $originalName
                     ];
                 } else {
@@ -185,8 +185,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['images'])) {
                     log_upload_error($msg);
                     // Si no se puede redimensionar, usar la original
                     $uploadedFiles[] = [
-                        'original' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
-                        'thumbnail' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
+                        'original' => $relativeBase . $fileName,
+                        'thumbnail' => $relativeBase . $fileName,
                         'name' => $originalName
                     ];
                 }


### PR DESCRIPTION
## Summary
- ensure upload handlers output relative image paths so products consistently display images

## Testing
- `php -d detect_unicode=0 test_system.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6877c1cbf844832685e836de3b07131c